### PR TITLE
fix font weights

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ safe: false
 markdown: kramdown
 permalink: pretty
 exclude: ['/automation/', 'README.md', 'LICENSE.txt', 'CNAME', 'vendor']
-
+sass: compact
 
 # Site Settings
 title: "CarpentryCon 2020"

--- a/_sass/partials/_base.scss
+++ b/_sass/partials/_base.scss
@@ -1,10 +1,10 @@
 @import "compass";
 
 // Font weights
-$light: 200;
-$regular: 320;
+$light: 300;
+$regular: 400;
 $bold: 500;
-$extra-bold: 600;
+$extra-bold: 700;
 
 // Base Font
 $base-font-family: sans-serif;
@@ -18,7 +18,7 @@ $fixed-font-size: 85%;
 $fixed-line-height: $base-line-height;
 
 // Headings
-$header-font-weight: $light;
+$header-font-weight: $bold;
 $h1-font-size: 6.125 * $base-font-size;
 $h2-font-size: 5.875 * $base-font-size;
 $h3-font-size: 5 * $base-font-size;

--- a/_sass/partials/_find-way.scss
+++ b/_sass/partials/_find-way.scss
@@ -28,7 +28,7 @@ $location-card-highlight-color: #333;
 }
 .map-card {
     font-size: 16px;
-    font-weight: 400;
+    font-weight: $bold;
     top: 450px;
     left: 50px;
     overflow: hidden;
@@ -114,7 +114,7 @@ $location-card-highlight-color: #333;
         list-style: none;
     }
     li {
-        font-weight: 400;
+        font-weight: $bold;
         line-height: 50px;
         text-transform: uppercase;
         color: $location-card-highlight-color;

--- a/_sass/partials/_global.scss
+++ b/_sass/partials/_global.scss
@@ -31,7 +31,7 @@ section {
 }
 p {
     font-size: 15px;
-    font-weight: 300;
+    font-weight: $regular;
     line-height: $base-line-height;
 }
 i {
@@ -47,7 +47,7 @@ a {
     }
 }
 #{headings()} {
-    font-weight: $light;
+    font-weight: $headings-font-weight;
     display: block;
 }
 h1 {

--- a/_sass/partials/_hero.scss
+++ b/_sass/partials/_hero.scss
@@ -25,7 +25,7 @@
         }
         p {
             font-size: $base-font-size * 2;
-            font-weight: $light;
+            font-weight: $regular;
             margin-bottom: 15px;
         }
         .btn {

--- a/_sass/partials/_navigation.scss
+++ b/_sass/partials/_navigation.scss
@@ -103,7 +103,7 @@ nav {
         }
         a {
             font-size: 18px;
-            font-weight: 400;
+            font-weight: $bold;
             transition: $base-transition;
             text-transform: uppercase;
             color: $nav-color;

--- a/_sass/partials/_ribbon.scss
+++ b/_sass/partials/_ribbon.scss
@@ -33,7 +33,7 @@ $wt-ribbon-border-color: #72e1b3;
     }
     .ribbon {
         font-size: 13px;
-        font-weight: 300;
+        font-weight: $regular;
         line-height: 22px;
         display: inline-block;
         float: right;

--- a/_sass/vendor/bootstrap/_buttons.scss
+++ b/_sass/vendor/bootstrap/_buttons.scss
@@ -87,7 +87,7 @@
 // Make a button look and behave like a link
 .btn-link {
   color: $link-color;
-  font-weight: normal;
+  font-weight: $base-font-weight;
   border-radius: 0;
 
   &,

--- a/_sass/vendor/bootstrap/_dropdowns.scss
+++ b/_sass/vendor/bootstrap/_dropdowns.scss
@@ -65,7 +65,7 @@
     display: block;
     padding: 3px 20px;
     clear: both;
-    font-weight: normal;
+    font-weight: $base-font-weight;
     line-height: $line-height-base;
     color: $dropdown-link-color;
     white-space: nowrap; // prevent links from randomly breaking onto new lines

--- a/_sass/vendor/bootstrap/_forms.scss
+++ b/_sass/vendor/bootstrap/_forms.scss
@@ -219,7 +219,7 @@ input[type="search"] {
     min-height: $line-height-computed; // Ensure the input doesn't jump when there is no text
     padding-left: 20px;
     margin-bottom: 0;
-    font-weight: normal;
+    font-weight: $base-font-weight;
     cursor: pointer;
   }
 }
@@ -244,7 +244,7 @@ input[type="search"] {
   padding-left: 20px;
   margin-bottom: 0;
   vertical-align: middle;
-  font-weight: normal;
+  font-weight: $base-font-weight;
   cursor: pointer;
 }
 .radio-inline + .radio-inline,

--- a/_sass/vendor/bootstrap/_glyphicons.scss
+++ b/_sass/vendor/bootstrap/_glyphicons.scss
@@ -25,7 +25,7 @@
   display: inline-block;
   font-family: 'Glyphicons Halflings';
   font-style: normal;
-  font-weight: normal;
+  font-weight: $base-font-weight;
   line-height: 1;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/_sass/vendor/bootstrap/_input-groups.scss
+++ b/_sass/vendor/bootstrap/_input-groups.scss
@@ -73,7 +73,7 @@
 .input-group-addon {
   padding: $padding-base-vertical $padding-base-horizontal;
   font-size: $font-size-base;
-  font-weight: normal;
+  font-weight: $base-font-weight;
   line-height: 1;
   color: $input-color;
   text-align: center;

--- a/_sass/vendor/bootstrap/_jumbotron.scss
+++ b/_sass/vendor/bootstrap/_jumbotron.scss
@@ -17,7 +17,7 @@
   p {
     margin-bottom: ($jumbotron-padding / 2);
     font-size: $jumbotron-font-size;
-    font-weight: 200;
+    font-weight: $base-font-weight;
   }
 
   > hr {

--- a/_sass/vendor/bootstrap/_labels.scss
+++ b/_sass/vendor/bootstrap/_labels.scss
@@ -6,7 +6,7 @@
   display: inline;
   padding: .2em .6em .3em;
   font-size: 75%;
-  font-weight: bold;
+  font-weight: $bold;
   line-height: 1;
   color: $label-color;
   text-align: center;

--- a/_sass/vendor/bootstrap/_normalize.scss
+++ b/_sass/vendor/bootstrap/_normalize.scss
@@ -116,7 +116,7 @@ abbr[title] {
 
 b,
 strong {
-  font-weight: bold;
+  font-weight: $bold;
 }
 
 //
@@ -406,7 +406,7 @@ textarea {
 //
 
 optgroup {
-  font-weight: bold;
+  font-weight: $bold;
 }
 
 // Tables

--- a/_sass/vendor/bootstrap/_popovers.scss
+++ b/_sass/vendor/bootstrap/_popovers.scss
@@ -14,7 +14,7 @@
   // Reset font and text properties given new insertion method
   font-family: $font-family-base;
   font-size: $font-size-base;
-  font-weight: normal;
+  font-weight: $base-font-weight;
   line-height: $line-height-base;
   text-align: left;
   background-color: $popover-bg;

--- a/_sass/vendor/bootstrap/_tooltip.scss
+++ b/_sass/vendor/bootstrap/_tooltip.scss
@@ -12,7 +12,7 @@
   // Reset font and text properties given new insertion method
   font-family: $font-family-base;
   font-size: $font-size-small;
-  font-weight: normal;
+  font-weight: $base-font-weight;
   line-height: 1.4;
   @include opacity(0);
 

--- a/_sass/vendor/bootstrap/_type.scss
+++ b/_sass/vendor/bootstrap/_type.scss
@@ -15,9 +15,9 @@ h1, h2, h3, h4, h5, h6,
 
   small,
   .small {
-    font-weight: normal;
-    line-height: 1;
-    color: $headings-small-color;
+      font-weight: $base-font-weight;
+      line-height: 1;
+      color: $headings-small-color;
   }
 }
 
@@ -62,7 +62,7 @@ p {
 .lead {
   margin-bottom: $line-height-computed;
   font-size: floor(($font-size-base * 1.15));
-  font-weight: 300;
+  font-weight: $base-font-weight;
   line-height: 1.4;
 
   @media (min-width: $screen-sm-min) {
@@ -191,7 +191,7 @@ dd {
   line-height: $line-height-base;
 }
 dt {
-  font-weight: bold;
+  font-weight: $bold;
 }
 dd {
   margin-left: 0; // Undo browser default

--- a/_sass/vendor/bootstrap/_variables.scss
+++ b/_sass/vendor/bootstrap/_variables.scss
@@ -67,7 +67,7 @@ $line-height-computed:    floor(($font-size-base * $line-height-base)) !default;
 
 //** By default, this inherits from the `<body>`.
 $headings-font-family:    inherit !default;
-$headings-font-weight:    500 !default;
+$headings-font-weight:    $bold !default;
 $headings-line-height:    1.1 !default;
 $headings-color:          inherit !default;
 
@@ -147,7 +147,7 @@ $table-border-color:            #ddd !default;
 //
 //## For each of Bootstrap's buttons, define text, background and border color.
 
-$btn-font-weight:                normal !default;
+$btn-font-weight:                $regular !default;
 
 $btn-default-color:              #333 !default;
 $btn-default-bg:                 #fff !default;
@@ -617,7 +617,7 @@ $modal-sm:                    300px !default;
 
 $alert-padding:               15px !default;
 $alert-border-radius:         $border-radius-base !default;
-$alert-link-font-weight:      bold !default;
+$alert-link-font-weight:      $bold !default;
 
 $alert-success-bg:            $state-success-bg !default;
 $alert-success-text:          $state-success-text !default;
@@ -773,7 +773,7 @@ $badge-active-color:          $link-color !default;
 //** Badge background color in active nav link
 $badge-active-bg:             #fff !default;
 
-$badge-font-weight:           bold !default;
+$badge-font-weight:           $bold !default;
 $badge-line-height:           1 !default;
 $badge-border-radius:         10px !default;
 
@@ -815,7 +815,7 @@ $carousel-caption-color:                      #fff !default;
 //
 //##
 
-$close-font-weight:           bold !default;
+$close-font-weight:           $bold !default;
 $close-color:                 #000 !default;
 $close-text-shadow:           0 1px 0 #fff !default;
 


### PR DESCRIPTION
this PR harmonizes the font weights across the sites.
For Roboto (and given the rest of the CSS) the valid options for font weights are: 300, 400, 500, 700. Other available options are 100 and 900.