### PR TITLE
"scholarship" --> "financial aid"

### DIFF
--- a/_posts/2019-12-11-carpentrycon-financial-aid.markdown
+++ b/_posts/2019-12-11-carpentrycon-financial-aid.markdown
@@ -7,11 +7,11 @@ isStaticPost: false
 
 In order to promote as well as grow inclusive, computational communities and leaders, we are providing a limited amount of financial support to facilitate participation at CarpentryCon 2020 in Madison.
 
-These scholarships are aimed at, but not limited to postgraduate students, early-career researchers and academics who are unable to fully meet conference expenses through other funding means. Interested applicants should be able to demonstrate their potential for leadership and the creation of value for computational research by expanding the reach of the Carpentries in their communities and beyond.
+This financial aid is aimed at, but not limited to postgraduate students, early-career researchers and academics who are unable to fully meet conference expenses through other funding means. Interested applicants should be able to demonstrate their potential for leadership and the creation of value for computational research by expanding the reach of the Carpentries in their communities and beyond.
 
 In the interest of spreading our financial aid funding to its greatest extent, potential CarpentryCon 2020 attendees are encouraged to first exhaust other potential means of funding before applying for this grant. In the application form, it is possible to apply for various types of financial support, accommodating those who may be able to secure funding for one part of conference costs (like travel) but not another part (like the registration fee or visa costs).
 
-The total amount of funding for Carpentry Con 2020 scholarships will depend greatly on sponsorship and donations, so at this time we cannot how much money will be available per individual or how many individuals will receive financial support. This also means that financial support will likely be granted on a rolling basis, rather than all at once. We aim to keep both applicants and the broader community up-to-date as we progress towards the conference in June 2020. 
+The total amount of funding for Carpentry Con 2020 financial aid will depend greatly on sponsorship and donations, so at this time we cannot how much money will be available per individual or how many individuals will receive financial support. This also means that financial support will likely be granted on a rolling basis, rather than all at once. We aim to keep both applicants and the broader community up-to-date as we progress towards the conference in June 2020. 
 
 The application form is available at: [CarpentryCon 2020 Financial Support Application](https://docs.google.com/forms/d/e/1FAIpQLSf3vWlTy79TXAboT6VPElllq6ggYsSEb5QairmhU01kOHD_Dg/viewform).
 


### PR DESCRIPTION
changing language from "scholarship" to "financial aid" for legal compliance with CI's policies. Already made the corresponding change on The Carpentries blog.