### PR TITLE
add COVID19 update blurb

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,7 +69,7 @@ heroButtons:
   - {link: "https://github.com/carpentries/conversations/issues/22", text: "Design a t-shirt"}
   - {link: "https://carpentries.typeform.com/to/hqoY3I", text: "Become a Sponsor"}
 heroTheme: "Growing Inclusive, Computational Communities and Leaders"
-
+heroAnnouncement: "<br/><br/>CarpentryCon 2020 is still scheduled to take place. <br/> We are monitoring the COVID-19 situation closely and will issue another update on April 1, 2020."
 
 # About Block
 aboutTitle: " CarpentryCon Conference Format"

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -16,6 +16,7 @@
             <a href="{% if button.permalink != null %} {{ button.permalink | prepend: site.baseurl }} {% else %} {{ button.link }} {% endif %}" class="btn btn-primary waves-effect waves-button waves-light waves-float" {% if button.link != null %}target="_blank"{% endif %}>{{ button.text }}</a>
             {% endfor %}
         </div>
+        <p style="color:#fffff6; font-size:20px;">{{ site.heroAnnouncement }}</p>
     </div>
     <a href="#about" class="explore">
         <svg class="icon icon-arrow-down" viewBox="0 0 32 32">


### PR DESCRIPTION
**Text:**
CarpentryCon 2020 is still scheduled to take place. <br/> We are monitoring the COVID-19 situation closely and will issue another update on April 1, 2020.

**Context:**
[This post](https://carpentries.org/blog/2020/03/covid-19-update/) was published on The Carpentries blog on March 9, 2020.

**Merging the PR will append the update as in the screen grab below:**

**a. On Safari:**
<img width="1751" alt="Screenshot 2020-03-10 at 11 25 45" src="https://user-images.githubusercontent.com/4550385/76298353-fcefb700-62c1-11ea-87ba-70fc8e5ec932.png">

**b. On Chrome:**
<img width="1692" alt="Screenshot 2020-03-10 at 11 26 00" src="https://user-images.githubusercontent.com/4550385/76298362-fe20e400-62c1-11ea-88a8-15de2d7a860a.png">
