### PR TITLE
add link to etherpad to each session description

### DIFF
--- a/_includes/sessions-modals.html
+++ b/_includes/sessions-modals.html
@@ -23,7 +23,7 @@
 						    <iframe class="embed-responsive-item" src="{{ session.video }}"></iframe>
 						</div>
 						{% endif %}
-						<p class="theme-description">{{ session.description }}</p>
+						<p class="theme-description">{{ session.description }} <br><br> Visit the CarpentryCon 2020 Etherpad for more information: <a href="https://pad.carpentries.org/carpentryconathome">https://pad.carpentries.org/carpentryconathome</a>  </p>
 						{% if session.presentation %}
 						<a class="theme-presentation" href="{{ session.presentation }}" title="Presentation" target="_blank">View presentation</a>
 						{% endif %}


### PR DESCRIPTION
Chatting with Sher who said that you are directing everyone to the main Etherpad to get more info on any session.  She suggested adding the etherpad to each description.